### PR TITLE
Only build Docker image on main, not on PRs

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*' ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:  # Allow manual trigger
 
 env:
@@ -27,7 +25,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -41,7 +38,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
+
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -52,14 +49,13 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Test image (health check)
-        if: github.event_name != 'pull_request'
         run: |
           echo "Waiting for image to be available..."
           sleep 5


### PR DESCRIPTION
## Summary
- Remove `pull_request` trigger from the build-and-publish workflow
- Docker images are now only built and pushed on pushes to `main`, version tags, or manual dispatch
- Cleans up the now-unnecessary `pull_request` conditional guards on login, push, and test steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)